### PR TITLE
Update build time to utc 0am for gccefi2linux

### DIFF
--- a/.github/workflows/gccefi2linux.yml
+++ b/.github/workflows/gccefi2linux.yml
@@ -1,7 +1,7 @@
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 16 * * *'
+    - cron: '0 0 * * *'
 
 name: Build and upload gccefi2linux compiler nightly build
 


### PR DESCRIPTION
Update build time to utc 0am for gccefi2linux nightly build.